### PR TITLE
[HOMEWORK-TASK-1] Added validation for note content length

### DIFF
--- a/src/components/create-note/create-note.tsx
+++ b/src/components/create-note/create-note.tsx
@@ -113,7 +113,7 @@ export function CreateNote({handleModalClose, maxTitleLength = 20, editableNote,
                 <Label>Title ({titleCounter})</Label>
                 <ContentEditableStyled
                     html={titleValue}
-                    onChange={(e) => {handleTitleLength(e)}}
+                    onChange={handleTitleLength}
                 />
             </FormGroup>
             <FormGroup>


### PR DESCRIPTION
**WHAT?**
Implemented validation for content length in note creation and editing. If content length exceed 1000 characters, user can not create or edit note, because Save button become disabled. 
Also refactor some useState hooks to useMemo for optimization.

**HOW?**
1. Create new counter variable for detecting how many characters already typed and how many left.
2. Refactor way how disabling save button works. Now I use useMemo hook, where i check all requirements for making button disabled/enabled

**WHY**
I used useMemo hook for content length counter for better optimization. For same reason refactor some old code.